### PR TITLE
Monte en 2.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="Openfisca-Paris",
-    version="2.2.0",
+    version="2.2.1",
     description="Plugin OpenFisca pour les aides sociales de la mairie de Paris",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     author="Mairie de Paris, Incubateur de Services Numériques (SGMAP)",


### PR DESCRIPTION
La nouvelle façon de résoudre les dépendances de `pip` dans les fichiers `requirements.txt` semble plus prendre en compte les versions spécifiées dans `setup.py`. En effet, un changement de hash pour une spécification de la forme `git+https://github.com/openfisca/openfisca-paris.git@3fba54b#egg=openfisca-paris` ne garantie pas la mise à jour de la dépendance si la version n'est pas modifiée.

Il va falloir être plus rigoureux (c'est une bonne chose) dans la gestion des paquets.
