### PR TITLE
Fix version minimale  de la dépendance `openfisca-france`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="Openfisca-Paris",
-    version="3.6.2",
+    version="3.6.3",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 35.2.0, < 36',
-        'OpenFisca-France >= 142.0.1, < 143',
+        'OpenFisca-France >= 102, < 143',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description
Lors de la release ([v3.6.1](https://github.com/openfisca/openfisca-paris/pull/137/)) nous avons mis à jour la dépendance `openfisca-france` et augmenté la version minimale requise sans faire assez de tests.
Ce n’était pas nécessaire, cette PR a pour but de remettre la version `102` comme version minimale puisqu’elle ne semble pas causer problème.
