### PR TITLE
Met à jour OpenFisca-france en version 146

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="Openfisca-Paris",
-    version="3.7.0",
+    version="3.8.0",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'OpenFisca-Core >= 35.2.0, < 36',
-        'OpenFisca-France >= 102, < 146',
+        'OpenFisca-France >= 102, < 147',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
- Permet à OpenFisca-france-paris de fonctionner avec la version 146 d'OpenFisca-france.