### PR TITLE
Utilisation de openfisca-core 38.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'OpenFisca-Core >= 35.2.0, < 36',
+        'OpenFisca-Core >= 38.0.2, < 38.0.3',
         'OpenFisca-France >= 102, < 121'
     ],
     extras_require = {


### PR DESCRIPTION
Modifications apportées afin d'utiliser la version 38.0.2 d'openfisca-core pour être en phase avec openfisca-france.