### PR TITLE
Corrige l'étape deploy de la CI - twine : command not found

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9.9
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="Openfisca-Paris",
-    version="4.0.0",
+    version="4.0.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
# Description
Corrige le numéro de version de version de python utilisée dans l'étape de deploy qui cause l'erreur `twine : command not found`