### PR TITLE
Modifie la manière de s'authentifier à Pypi pour la publication de paquet

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -108,8 +108,8 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_USERNAME: __token__
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_OPENFISCA_PARIS }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -131,6 +131,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.openfisca-dependencies }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_TOKEN
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="Openfisca-Paris",
-    version="5.4.0",
+    version="5.4.1",
     author="OpenFisca Team",
     author_email="contact@openfisca.fr",
     classifiers=[


### PR DESCRIPTION
# Description

Suite à l'obligation de l 'authentification à double facteur, nous devons mettre à jour la manière dont la CI s'authentifie pour publier les paquets sur Pypi.

Nous avons choisi d'utiliser un token.